### PR TITLE
Potential fix for code scanning alert no. 1: Reflected cross-site scripting

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     },
     "dependencies": {
         "express": "4.21.2",
-        "express-http-proxy": "2.1.1"
+        "express-http-proxy": "2.1.1",
+        "escape-html": "^1.0.3"
     },
     "devDependencies": {
         "@types/express": "4.17.21",

--- a/src/xpProxy.ts
+++ b/src/xpProxy.ts
@@ -1,6 +1,7 @@
 import { RequestHandler } from 'express';
 import proxy from 'express-http-proxy';
 import * as fs from 'fs';
+import escape from 'escape-html';
 
 const XP_ORIGINS: Record<string, string> = {
     dev1: 'https://www.dev.nav.no',
@@ -29,7 +30,7 @@ export const xpProxy: RequestHandler = async (req, res, next) => {
     const xpOrigin = XP_ORIGINS[xpEnv];
 
     if (!xpOrigin) {
-        return res.status(400).send(`${xpEnv} is not a valid XP environment`);
+        return res.status(400).send(`${escape(xpEnv)} is not a valid XP environment`);
     }
 
     return proxy(xpOrigin, {


### PR DESCRIPTION
Potential fix for [https://github.com/navikt/nav-enonicxp-dev-proxy/security/code-scanning/1](https://github.com/navikt/nav-enonicxp-dev-proxy/security/code-scanning/1)

To fix the cross-site scripting vulnerability, we must sanitize or escape the user-provided value before placing it into the HTTP response. In Node.js and Express, a standard solution is to use the `escape-html` library to HTML-escape any user-derived content that may appear in rendered output. This ensures special characters such as `<`, `>`, and `&` are properly encoded and cannot be interpreted as HTML or JavaScript. Within the snippet, the change should be to wrap `xpEnv` in `escape()` (from `escape-html`) on line 32. Additionally, we need to import/require `escape-html` at the top of the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
